### PR TITLE
Upset multipattern selection

### DIFF
--- a/inst/d3/upset/helpers.js
+++ b/inst/d3/upset/helpers.js
@@ -357,7 +357,7 @@ function create_pattern_interaction_layer(g, patterns, scales, sizes, callbacks)
   const pattern_rows = g.selectAll('.pattern_row')
     .data(patterns)
     .enter().append('g.pattern_row')
-    .attr('id', d => make_id_string(d, 'pattern'))
+    .attr('id', d => make_id_string(d.pattern, 'pattern'))
     .translate((d,i) => [-sizes.padding, scales.pattern_y(i)] )
     .selectAppend('rect')
       .classed('interaction_box', true)
@@ -381,7 +381,7 @@ function create_code_interaction_layer(g, marginals, scales, sizes, callbacks){
   const code_cols = g.selectAll('.code_col')
     .data(marginals)
     .enter().append('g.code_col')
-    .attr('id', d => make_id_string(d, 'code'))
+    .attr('id', d => make_id_string(d.code, 'code'))
     .translate((d,i) => [scales.matrix_width_scale(d.code), -sizes.padding])
     .selectAppend('rect')
       .classed('interaction_box', true)
@@ -509,7 +509,7 @@ function make_set_size_slider(g, set_size_x, sizes, starting_min_size, on_releas
 function create_info_panel(g, panel_size, side = 'left'){
   const panel = g.selectAppend('g.info');
 
-  // How much into the margins should the text fall?
+          // How much into the margins should the text fall?
   const shift = 20;
   const width = panel_size[0];
 
@@ -659,6 +659,6 @@ function draw_singleton_filter_toggle(g, starting_filtered, on_click){
 }
 
 
-function make_id_string(d, code_or_pattern){
-  return `${code_or_pattern}_${d[code_or_pattern].replace(/\./g, '')}`;
+function make_id_string(id, type){
+  return `${type}_${id.replace(/\./g, '')}`;
 }

--- a/inst/d3/upset/upset.js
+++ b/inst/d3/upset/upset.js
@@ -6,8 +6,50 @@ let viz_options = options;
 let viz_width = width;
 let viz_height = height;
 
-let highlighted_pattern;
 let current_min_size;
+
+const highlights = {
+  type: "code",
+  values: new Set(),
+  reset_to: function(new_val) {
+    this.values.clear();
+    this.values.add(new_val);
+  },
+  add: function(val, multiselect_mode){
+    if (multiselect_mode) {
+      // User has requested more patterns or codes to be added to current selection
+      this.values.add(val);
+    } else {
+      // User has selected a new pattern or code that should be viewed in isolation
+      this.reset_to(val);
+    }
+  },
+  update: function(d, multiselect_mode){
+    const highlight_type = Object.keys(d).includes('pattern') ? 'pattern' : 'code';
+    const value = d[highlight_type];
+    const already_highlighted = this.values.has(value);
+
+    // User has switched the type of highlight they are doing from code->pattern or vis-versa
+    if(highlight_type !== this.type) {
+      this.reset_to(value);         // Reset to just this current value
+      this.type = highlight_type;   // Update current highlight type
+    } else if(already_highlighted && !multiselect_mode) {
+      this.reset_to(value);
+    } else if(already_highlighted){
+      this.values.delete(value);
+    } else {
+      this.add(value, multiselect_mode);
+    }
+  },
+  dump: function(){
+    return [...this.values];
+  },
+  as_element_ids: function(){
+    return this.dump().map(id => `#${make_id_string(id, this.type)}`);
+  }
+};
+
+
 
 // Constants
 const margin = {right: 50, left: 50, top: 20, bottom: 70}; // margins on side of chart
@@ -209,9 +251,7 @@ function draw_with_set_size(g, sizes, set_size_x, only_snp_data, remove_singleto
       left_info_panel.hide();
       d3.select(this).attr('stroke-width', 0);
   },
-    click: function(d){
-      toggle_pattern_highlight(d, 'pattern');
-    }
+    click: toggle_pattern_highlight
   };
 
   const code_callbacks = {
@@ -237,9 +277,7 @@ function draw_with_set_size(g, sizes, set_size_x, only_snp_data, remove_singleto
       right_info_panel.hide();
       d3.select(this).attr('stroke-width', 0);
     },
-    click: function(d){
-      toggle_pattern_highlight(d, 'code');
-    }
+    click: toggle_pattern_highlight
   };
 
   const code_interaction_layer = g.selectAppend('g.code_interaction_layer')
@@ -250,10 +288,8 @@ function draw_with_set_size(g, sizes, set_size_x, only_snp_data, remove_singleto
     .translate([0, sizes.margin_count_h])
     .call(create_pattern_interaction_layer, patterns, scales, sizes, pattern_callbacks);
 
-  // Redo old highlight if it's there
-  if(highlighted_pattern !== null){
-    highlight_or_reset_pattern(highlighted_pattern);
-  }
+  // Redo old highlight if it's there, don't update shiny though
+  highlight_or_reset_patterns(false);
 }
 
 function draw_upset(){
@@ -305,7 +341,7 @@ function draw_upset(){
         current_min_size,
         new_size => {
           current_min_size = new_size;
-          draw_with_set_size(g, sizes, set_size_x, filtered_on_snp, filtering_singletons)
+          draw_with_set_size(g, sizes, set_size_x, filtered_on_snp, filtering_singletons);
         });
 
     // Setup singleton filter button
@@ -338,6 +374,7 @@ r2d3.onRender((data, svg, width, height, options) => {
   viz_svg = svg;
   viz_options = options;
   draw_upset();
+
 });
 
 r2d3.onResize((width,height) => {
@@ -347,45 +384,28 @@ r2d3.onResize((width,height) => {
   draw_upset(viz_data, viz_svg, viz_width, viz_height, viz_options);
 });
 
-function highlight_or_reset_pattern(id_of_pattern, undoing_highlight = false){
-
-  // Can we find pattern in current view?
-  const pattern_holder = svg.select(`#${id_of_pattern}`);
-
-  // Is the pattern out of view?
-  const missing_pattern = pattern_holder.empty();
+function highlight_or_reset_patterns(pass_message = true){
 
   // Reset all boxes
   svg.selectAll('rect.interaction_box').at(interaction_box_styles);
 
-  if(missing_pattern || undoing_highlight){
-    // Unhighlight and send to shiny
-    highlighted_pattern = null;
-    send_to_shiny('pattern_highlight', [], viz_options.msg_loc || 'no_shiny');
-  } else {
-    // Otherwise, parse the pattern and send to shiny
-    pattern_holder.select('.interaction_box').at(selected_interaction_box);
-    highlighted_pattern = id_of_pattern;
+  // Highlight all the patterns requested
+  highlights.as_element_ids()
+    .forEach(element_id => svg
+      .select(element_id)
+      .select('.interaction_box')
+      .at(selected_interaction_box));
+
+  if(pass_message){
+    send_to_shiny('pattern_highlight', highlights.dump(), viz_options.msg_loc || 'no_shiny');
   }
 }
 
-function toggle_pattern_highlight(d, code_or_pattern){
-
-  const id_of_pattern = make_id_string(d, code_or_pattern);
-
-  // Is this pattern already highlighted? (thus we're turning it off?)
-  const undoing_highlight = id_of_pattern === highlighted_pattern;
+function toggle_pattern_highlight(d){
+  highlights.update(d, d3.event.shiftKey);
 
   // Perform the actual visual changes (and send to shiny if we're resetting to no highlight)
-  highlight_or_reset_pattern(id_of_pattern, undoing_highlight)
-
-  // If we're not simply reseting then update the current highlight and send to shiny the new
-  // pattern.
-  if(!undoing_highlight){
-    highlighted_pattern = id_of_pattern;
-    const codes_in_pattern = d[code_or_pattern].split('-');
-    send_to_shiny('pattern_highlight', codes_in_pattern, viz_options.msg_loc || 'no_shiny');
-  }
+  highlight_or_reset_patterns()
 }
 
 


### PR DESCRIPTION
You can now select multiple patterns in the upset plot by holding down the shift key while clicking. This allows the user to build custom patterns although I imagine won't see much use because the highlighting is still done by intersection. Meaning that if codes A, B, and C are selected, only ids with all three codes present will be highlighted. 