### PR TITLE
Fixed bug where table would not update to new results data

### DIFF
--- a/inst/d3/manhattan_plot/manhattan_plot.js
+++ b/inst/d3/manhattan_plot/manhattan_plot.js
@@ -345,6 +345,10 @@ r2d3.onRender(function(data, svg, width, height, options) {
   if(new_data){
     // Get data in proper format
     viz_data = process_new_data(data);
+
+    // Update table with new data
+    my_table.add_data(viz_data);
+
     // Update our timestamp so we can detect new data again
     loading_timestamp = options.timestamp;
   }


### PR DESCRIPTION
Previously when a new results dataset was loaded, whether for a new snp or with a new multiple comparisons correction applied, the table just held the same data from the very first time it loaded. Now it updates.