### PR TITLE
Network plot updates

### DIFF
--- a/inst/d3/network_plot/helpers.js
+++ b/inst/d3/network_plot/helpers.js
@@ -331,18 +331,12 @@ function draw_canvas_portion({nodes, links}, scales, {canvas, context}, C, highl
   // Draw patient nodes
   context.globalAlpha = C.case_opacity;
 
-  // Function to assign node highlights
-  // Only check for highlight modification if we need to to avoid expensive calculations
-  const node_border = d => highlighted_nodes.length != 0 ?
-    `rgba(0, 0, 0, ${highlighted_nodes.includes(d.name) ? 1 : 0})` :
-    `rgba(0, 0, 0, 0)`;
-
 
   nodes.forEach( d => {
     if(!d.selectable){
 
       // Border around the nodes.
-      context.strokeStyle = node_border(d);
+      context.strokeStyle = highlighted_nodes.includes(d.name) ? "black" : "white";
 
       context.fillStyle = d.color;
 

--- a/inst/d3/network_plot/helpers.js
+++ b/inst/d3/network_plot/helpers.js
@@ -29,7 +29,7 @@ function sanitize_data(data){
     nodes: data_props.includes('vertices') ? data.vertices : data.nodes,
     links: data_props.includes('edges') ? data.edges : data.links,
   };
-};
+}
 
 
 // Function to add a dx or dy point to nodes for fixing them on a line in force simulation
@@ -348,46 +348,6 @@ function draw_canvas_portion({nodes, links}, scales, {canvas, context}, C, highl
   });
 
 }
-
-
-// Logic for when a svg node is clicked.
-function on_node_click(d){
-  const node = d3.select(this);
-
-  // Is code already selected?
-  if(selected_codes.includes(d.name)){
-    // pull code out of selected list
-    selected_codes = selected_codes.filter(code => code !== d.name);
-
-    // reset the style of node
-    if(d.inverted){
-      node.attr("fill", 'white');
-    } else {
-      node.attr("stroke-width", 0);
-    }
-
-
-  } else {
-    // add code to selected codes list
-    selected_codes = [d.name, ...selected_codes];
-
-    // Emphasize highlight
-    if(d.inverted){
-      node.attr("fill", 'grey');
-    } else {
-      node.attr("stroke-width", 2);
-    }
-  }
-
-  // do we have selected codes currently? If so display the action popup.
-  if(selected_codes.length > 0){
-    dom_elements.message_buttons.show(
-      selected_codes.length === 1 ? ['Delete', 'Invert']: 'all'
-    );
-  } else {
-    dom_elements.message_buttons.hide();
-  }
-};
 
 
 // Finds which patient nodes contain a given pattern of codes.

--- a/inst/d3/network_plot/helpers.js
+++ b/inst/d3/network_plot/helpers.js
@@ -108,7 +108,18 @@ function setup_dom_elements(div, C, on_message){
     svg.at(viz_sizing)
        .st(viz_sizing);
 
-    canvas.at(viz_sizing);
+    // Get the device pixel ratio, falling back to 1.
+    const dpr = window.devicePixelRatio || 1;
+
+    canvas
+      .at({
+        width:   width*dpr,
+        height: height*dpr,
+      })
+      .st(viz_sizing);
+
+    // Scale canvas image so it looks good on retina displays
+    canvas.node().getContext('2d').scale(dpr,dpr);
   };
 
   return {svg, canvas, context, tooltip, message_buttons, resize};
@@ -309,7 +320,7 @@ function draw_canvas_portion({nodes, links}, scales, {canvas, context}, C, highl
   // Clear canvas
   context.clearRect(0, 0, +canvas.attr('width'), +canvas.attr('height'));
 
-  // If we're in export mode don't do anything.
+  // If we're in export mode we dont need to draw anything to the canvas.
   if(C.export_mode) return;
 
   context.save();
@@ -330,7 +341,6 @@ function draw_canvas_portion({nodes, links}, scales, {canvas, context}, C, highl
 
   // Draw patient nodes
   context.globalAlpha = C.case_opacity;
-
 
   nodes.forEach( d => {
     if(!d.selectable){

--- a/inst/d3/network_plot/index.js
+++ b/inst/d3/network_plot/index.js
@@ -546,11 +546,12 @@ function draw_svg_nodes({
 }
 
 function choose_fill({name, inverted, color}){
+  const selected = selected_codes.includes(name);
 
-  if(selected_codes.includes(name)){
-    return "grey"
-  } else if(inverted) {
-    return "white"
+  if(selected && inverted) {
+    return "grey";
+  } else if (inverted) {
+    return "white";
   } else {
     return color;
   }
@@ -571,8 +572,15 @@ function choose_stroke_width(d){
   }
 };
 
-function choose_stroke_color(d){
-  return d.inverted ? d.color : 'white';
+function choose_stroke_color({name, inverted, color}){
+  const selected = selected_codes.includes(name);
+  if(inverted){
+    return color;
+  } else if (selected) {
+    return "grey";
+  } else {
+    return "white";
+  }
 }
 
 
@@ -632,3 +640,32 @@ const export_mode_button = settings_menu.selectAppend('button.export_mode_button
 
     size_viz(viz.width, viz.height);
 });
+
+
+// Logic for when a svg node is clicked.
+function on_node_click(d){
+
+  if(selected_codes.includes(d.name)){
+    // pull code out of selected list
+    selected_codes = selected_codes.filter(code => code !== d.name);
+  } else {
+    // add code to selected codes list
+    selected_codes = [d.name, ...selected_codes];
+  }
+
+  // Update node style
+  d3.select(this).at({
+    stroke: choose_stroke_color(d),
+    strokeWidth: choose_stroke_width(d),
+  });
+
+  // do we have selected codes currently? If so display the action popup.
+  if(selected_codes.length > 0){
+    dom_elements.message_buttons.show(
+      selected_codes.length === 1 ? ['Delete', 'Invert']: 'all'
+    );
+  } else {
+    dom_elements.message_buttons.hide();
+  }
+}
+

--- a/inst/d3/network_plot/index.js
+++ b/inst/d3/network_plot/index.js
@@ -572,7 +572,7 @@ function choose_stroke_width(d){
 };
 
 function choose_stroke_color(d){
-  return d.inverted ? 'black' : 'white';
+  return d.inverted ? d.color : 'white';
 }
 
 

--- a/inst/d3/network_plot/index.js
+++ b/inst/d3/network_plot/index.js
@@ -185,10 +185,6 @@ function setup_network_viz(dom_elements, on_node_click){
                 ? {stroke: "black", strokeWidth: 1}
                 : {stroke: "white", strokeWidth: 0.5}
                );
-        })
-        .at({
-          stroke: 'black',
-          strokeWidth: d => nodes_to_highlight.includes(d.name) ? 1: choose_stroke_width(d),
         });
 
     } else {
@@ -576,7 +572,7 @@ function choose_stroke_width(d){
 };
 
 function choose_stroke_color(d){
-  return d.inverted ?  'white': 'black';
+  return d.inverted ? 'black' : 'white';
 }
 
 


### PR DESCRIPTION
This PR makes a few improvements to the network plot. 
1. Nodes now have a default white border around them to make them less blob-like in high-density networks
2. The functions for controlling node style have been made global so they can be used in all rendering contexts, making updating style easier. 
3. Support for retina displays was added to the canvas rendering mode. This makes it much sharper than before when not in export mode. 
4. General simplification of a few functions, in-particular node highlighting. 