### PR TITLE
Standalone manhattan plot

### DIFF
--- a/R/mod_manhattan_and_table.R
+++ b/R/mod_manhattan_and_table.R
@@ -71,7 +71,9 @@ manhattan_plot_and_table_UI <- function(id) {
 #' @param colors A list of CSS-valid colors to paint interface in. Needs
 #'   \code{light_grey, med_grey, dark_grey, light_blue}.
 #' @param action_object A \code{reactiveVal} that will be updated by the module
-#'   upon selection
+#'   upon selection. If nothing is passed then no action buttons (E.g. "Send to
+#'   server") will be shown. Useful for building apps with just the manhattan
+#'   plot.
 #' @return Server component of interactive manhattan plot. Returns type-payload
 #'   list with the type \code{"selection"} to the passed \code{action_object}
 #'   for updating app state.

--- a/R/mod_manhattan_and_table.R
+++ b/R/mod_manhattan_and_table.R
@@ -85,8 +85,10 @@ manhattan_plot_and_table <- function(input,
                                      results_data,
                                      selected_codes,
                                      colors,
-                                     action_object) {
+                                     action_object = NULL) {
   message_path <- 'message_manhattan_plot_and_table'
+
+  msg_loc <- if(is.null(action_object)) "standalone" else session$ns(message_path)
 
   timestamp <- Sys.time()
 
@@ -108,7 +110,7 @@ manhattan_plot_and_table <- function(input,
         system.file("css/common.css", package = "meToolkit")
       ),
       options = list(
-        msg_loc = session$ns(message_path),
+        msg_loc = msg_loc,
         selected = selected_codes(),
         sig_bar_locs = input$significance_threshold,
         colors = colors,

--- a/docs/articles/meToolkit.html
+++ b/docs/articles/meToolkit.html
@@ -102,8 +102,22 @@
 <h2 class="hasAnchor">
 <a href="#preloading-data" class="anchor"></a>Preloading data</h2>
 <p>If a set of results are going to be repeatedly visited in the app, the data for the results can be preloaded to save time. Once data is preloaded it populates a dropdown menu on the data-loading screen that can be used to select the desired dataset.</p>
-<p>To do this, the data must be loaded into a path (relative to the main app working directory) provided to <code>run_data_loader()</code> in the <code>preloaded_data_path</code> argument . The patient phenome file must be stored at <code>preloaded_data_loc/id_to_code.csv</code>, and each individual SNP’s patient-to-snp and phewas results stored in <code>preloaded_data_loc/&lt;SNP_ID&gt;/id_to_snp.csv</code> and <code>preloaded_data_loc/&lt;SNP_ID&gt;/phewas_results.csv</code> respectively.</p>
-<p><em>Note that due to sharing the same phenome mappings, all preloaded phewas results must be done on the same population.</em></p>
+<p>To do this, the data must be loaded into a path (relative to the main app working directory) provided to <code>run_data_loader()</code> in the <code>preloaded_data_path</code> argument.</p>
+<p><strong>Phenome Data:</strong> If the patient phenome file is common between all preloaded results it can be stored at <code>preloaded_data_loc/id_to_code.csv</code>. If it is unique to a given result set it can be set in that SNP’s subfolder with the same name: e.g. <code>preloaded_data_loc/&lt;SNP_ID&gt;/id_to_code.csv</code>. If a phenome mapping dataset is provided for a SNP it will always take priority over the app-wide mapping.</p>
+<p><strong>Genome Data:</strong> Each individual SNP’s patient-to-snp data us stored in <code>preloaded_data_loc/&lt;SNP_ID&gt;/id_to_snp.csv</code></p>
+<p><strong>PheWAS Results:</strong> The PheWAS results for the SNP go in as <code>preloaded_data_loc/&lt;SNP_ID&gt;/phewas_results.csv</code> respectively.</p>
+<p>As an example, this is what the file preloaded directory structure looks like for a hosted PheWAS-ME application with two preloaded snps.</p>
+<pre><code>$ tree app_w_preloaded_data/
+├── app.R
+└── preloaded_data
+    ├── id_to_code.csv
+    ├── rs123456
+    │   ├── id_to_snp.csv
+    │   └── phewas_results.csv
+    └── rs200445019
+        ├── id_to_code.csv
+        ├── id_to_snp.csv
+        └── phewas_results.csv</code></pre>
 </div>
 <div id="accessing-app" class="section level1">
 <h1 class="hasAnchor">
@@ -111,15 +125,15 @@
 <p>There are two main ways to access Multimorbidity Explorer.</p>
 <p><strong>Hosted</strong> The first is to go to the hosted example at prod.tbilab.org/multimorbidity_explorer. Here you can run the app on preloaded simulated data or upload your own data. No uploaded data is saved on the hosting server.</p>
 <p><strong>Self-Hosting</strong> If data privacy is a concern, the app can be run entirely locally on any computer with R installed and the ability to install packages. To run locally install the <code>meToolkit</code> package from github using the <code>devtools</code> package…</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1"></a>devtools<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/devtools/man/remote-reexports.html">install_github</a></span>(<span class="st">'tbilab/meToolkit'</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1"></a>devtools<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/devtools/man/remote-reexports.html">install_github</a></span>(<span class="st">'tbilab/meToolkit'</span>)</span></code></pre></div>
 <p>Once the package is installed the app can be launched with the data loading interface using the command</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1"></a>meToolkit<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/meToolkit/man/build_me_w_loader.html">build_me_w_loader</a></span>()</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1"></a>meToolkit<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/meToolkit/man/build_me_w_loader.html">build_me_w_loader</a></span>()</span></code></pre></div>
 <p><strong>Customizing with R API</strong> The <code>meToolkit</code> package is setup modularly so the data loading page can be skipped if data is provided directly to the app via the function <code><a href="../reference/build_me_dashboard.html">meToolkit::build_me_dashboard()</a></code>.</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1"></a>my_ME_app &lt;-<span class="st"> </span><span class="kw"><a href="../reference/build_me_dashboard.html">build_me_dashboard</a></span>(</span>
-<span id="cb3-2"><a href="#cb3-2"></a>  phewas_table,</span>
-<span id="cb3-3"><a href="#cb3-3"></a>  id_to_snp,</span>
-<span id="cb3-4"><a href="#cb3-4"></a>  phenotype_id_pairs</span>
-<span id="cb3-5"><a href="#cb3-5"></a>)</span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1"></a>my_ME_app &lt;-<span class="st"> </span><span class="kw"><a href="../reference/build_me_dashboard.html">build_me_dashboard</a></span>(</span>
+<span id="cb4-2"><a href="#cb4-2"></a>  phewas_table,</span>
+<span id="cb4-3"><a href="#cb4-3"></a>  id_to_snp,</span>
+<span id="cb4-4"><a href="#cb4-4"></a>  phenotype_id_pairs</span>
+<span id="cb4-5"><a href="#cb4-5"></a>)</span></code></pre></div>
 <p>The data format for <code>phewas_table</code>, <code>id_to_snp</code>, and <code>phenotype_id_pairs</code> follows exactly from the required input files as outlined in <a href="#Data">the Data section</a></p>
 <p>For further information on customizing applications read the packages documentation at prod.tbilab.org/meToolkit.</p>
 </div>

--- a/docs/reference/build_me_w_loader.html
+++ b/docs/reference/build_me_w_loader.html
@@ -148,6 +148,19 @@ minor allele in network plot.</p></td>
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
     <p>Shiny app process</p>
+    <h2 class="hasAnchor" id="preloading-data"><a class="anchor" href="#preloading-data"></a>Preloading data</h2>
+
+    <p>If a set of results are going to be repeatedly
+visited in the app, the data for the results can be preloaded to save time.
+Once data is preloaded it populates a dropdown menu on the data-loading
+screen that can be used to select the desired dataset. To do this, the data
+must be loaded into a path (relative to the main app working directory)
+provided to <code>run_data_loader()</code> in the <code>preloaded_data_path</code> argument.
+The neccesary files, relative to <code>preloaded_data_loc/</code> are:</p><ul>
+<li><p><code>&lt;SNP_ID&gt;/id_to_code.csv</code> or <code>id_to_code.csv</code>:  Subject-level phenome file (if left in main preloaded directory is used as common phenome)</p></li>
+<li><p><code>&lt;SNP_ID&gt;/id_to_snp.csv</code>: Subject-level genotype file</p></li>
+<li><p><code>&lt;SNP_ID&gt;/phewas_results.csv</code>: PheWAS results</p></li>
+</ul><p>For further details on the format of these dataset see the <a href='https://prod.tbilab.org/phewas_me_manual/articles/meToolkit.html'>getting started article on package website.</a></p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
@@ -159,6 +172,7 @@ minor allele in network plot.</p></td>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
       <li><a href="#value">Value</a></li>
+      <li><a href="#preloading-data">Preloading data</a></li>
       <li><a href="#examples">Examples</a></li>
     </ul>
 

--- a/docs/reference/manhattan_plot_and_table.html
+++ b/docs/reference/manhattan_plot_and_table.html
@@ -126,7 +126,7 @@ selections for codes to the rest of the app.</p>
   <span class='no'>results_data</span>,
   <span class='no'>selected_codes</span>,
   <span class='no'>colors</span>,
-  <span class='no'>action_object</span>
+  <span class='kw'>action_object</span> <span class='kw'>=</span> <span class='kw'>NULL</span>
 )</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -155,7 +155,9 @@ that are currently selected in the app.</p></td>
     <tr>
       <th>action_object</th>
       <td><p>A <code>reactiveVal</code> that will be updated by the module
-upon selection</p></td>
+upon selection. If nothing is passed then no action buttons (E.g. "Send to
+server") will be shown. Useful for building apps with just the manhattan
+plot.</p></td>
     </tr>
     </table>
 

--- a/inst/d3/manhattan_plot/manhattan_plot.js
+++ b/inst/d3/manhattan_plot/manhattan_plot.js
@@ -53,6 +53,7 @@ const buttons = div.append('div.buttons')
      position: 'absolute',
      right: 10,
      top: 2,
+     display: options.msg_loc == "standalone" ? "none": "block",
   });
 
 const send_button = buttons.append('button')

--- a/inst/manhattan_only/app.R
+++ b/inst/manhattan_only/app.R
@@ -1,0 +1,114 @@
+# testing main app module in own shiny app.
+library(shiny)
+library(readr)
+library(meToolkit)
+
+app_title <- "Just Manhattan Plot"
+phewas_results <- readr::read_csv(here::here('inst/demo_app/data/phewas_results.csv'))
+# > phewas_results
+# # A tibble: 1,578 x 5
+#     code   description                                         OR  p_val category
+#     <chr>  <chr>                                            <dbl>  <dbl> <chr>
+#   1 401.22 Hypertensive chronic kidney disease              0.733 0.337  circulatory system
+#   2 401.30 Other hypertensive complications                 1.47  0.0588 circulatory system
+#   3 411.00 Ischemic Heart Disease                           0.848 0.283  circulatory system
+
+id_to_snp <-      readr::read_csv(here::here('inst/demo_app/data/id_to_snp.csv'))
+# > id_to_snp
+# # A tibble: 1,000 x 2
+#     IID   rs123456
+#     <chr>    <dbl>
+#   1 r1           1
+#   2 r10          0
+#   3 r100         0
+#   4 r1000        0
+
+id_to_phenome <- readr::read_csv(here::here('inst/demo_app/data/id_to_phenome.csv'))
+# > id_to_phenome
+# # A tibble: 43,316 x 2
+#     IID   code
+#     <chr> <chr>
+#   1 r1    008.00
+#   2 r104  008.00
+#   3 r145  008.00
+#   4 r186  008.00
+#   5 r188  008.00
+
+# Setup data in the module-friendly combined format
+data_for_shiny <- reconcile_data(phewas_results, id_to_snp, id_to_phenome, "none")
+data_for_shiny$phewas_results <- data_for_shiny$phewas_results
+cat_colors <- phewasHelper::category_colors()
+data_for_shiny$phewas_results$color <- cat_colors[data_for_shiny$phewas_results$category]
+
+styles <- "
+  body {
+    box-sizing: border-box;
+    margin: 0 2px;
+    background-color: #bdbdbd;
+    --section-title-height: 2.3rem;
+  }
+
+  .title-bar {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px solid #69696926;
+    padding: 2px;
+    margin-bottom: 2px;
+    height: var(--section-title-height);
+  }
+
+  .app_holder{
+    height: 100vh;
+    width: 95vw;
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: white;
+    box-shadow: 3px 3px 5px 0px rgba(0,0,0,0.49);
+    border-radius: 4px;
+    padding: 1.5rem;
+    overflow: hidden;
+  }
+
+  #app_title {
+    margin: 0 0 0.7rem 0px;
+    padding: 0;
+    border-bottom: 1px solid #080808;
+    height: 40px;
+  }
+
+"
+app_ui <- shiny::htmlTemplate(
+  system.file("html_templates/empty_page.html", package = "meToolkit"),
+  app_content = tagList(
+    shiny::tags$style(styles),
+    shiny::div(
+      class = "app_holder",
+      shiny::h1(app_title, id = "app_title"),
+      meToolkit::manhattan_plot_and_table_UI('manhattan_plot_and_table'),
+    )
+  )
+)
+
+app_server <- function(input, output, session) {
+  selected_codes <- data_for_shiny$phewas_results %>%
+    dplyr::filter(p_val < 0.01) %>%
+    dplyr::pull(code) %>%
+    shiny::reactiveVal()
+
+  ## Manhattan plot
+  shiny::callModule(
+    meToolkit::manhattan_plot_and_table,
+    'manhattan_plot_and_table',
+    results_data = data_for_shiny$phewas_results,
+    selected_codes = selected_codes,
+    colors = list(
+      light_grey = "#f7f7f7",
+      med_grey   = "#d9d9d9",
+      light_blue = "#4292c6",
+      green      = "#74c476"
+    )
+  )
+}
+
+shinyApp(app_ui, app_server)

--- a/man/manhattan_plot_and_table.Rd
+++ b/man/manhattan_plot_and_table.Rd
@@ -11,7 +11,7 @@ manhattan_plot_and_table(
   results_data,
   selected_codes,
   colors,
-  action_object
+  action_object = NULL
 )
 }
 \arguments{
@@ -28,7 +28,9 @@ that are currently selected in the app.}
 \code{light_grey, med_grey, dark_grey, light_blue}.}
 
 \item{action_object}{A \code{reactiveVal} that will be updated by the module
-upon selection}
+upon selection. If nothing is passed then no action buttons (E.g. "Send to
+server") will be shown. Useful for building apps with just the manhattan
+plot.}
 }
 \value{
 Server component of interactive manhattan plot. Returns type-payload


### PR DESCRIPTION
Adds tiny tweaks to manhattan plot and table module to make it easier to use them standalone. It also adds a demo app doing just this. 

No changes to existing API. Just the manhattan plot now is smart and won't show buttons to send updates to server etc when there is no reactive object available to it to do so. 